### PR TITLE
gh-966 cleanup ECR/Docker pipeline helpers

### DIFF
--- a/vars/paktorDockerImage.groovy
+++ b/vars/paktorDockerImage.groovy
@@ -4,7 +4,7 @@
  * Build and publish docker image. Image name comes from jenkins job
  *
  */
-def call(repository = 'dr.gopaktor.com/paktor', region = 'ap-southeast-1') {
+def call(repository = 'dr.gopaktor.com/paktor') {
     paktorCheckout scm
 
     def imageName = (env.JOB_NAME =~ /docker-images\//).replaceFirst('')
@@ -12,15 +12,11 @@ def call(repository = 'dr.gopaktor.com/paktor', region = 'ap-southeast-1') {
   	ws(pwd() + "/docker-${imageName}") {
 		def img
 
-        def fullImageName = "${repository}/${imageName}:${env.BUILD_NUMBER}"
-
     	stage ('Build image') {
-            img = docker.build "${fullImageName}"
+            img = docker.build "${repository}/${imageName}:${env.BUILD_NUMBER}"
     	}
 
     	stage ('Publish image') {
-            aws_ecr_login("--no-include-email --region=$region")
-
   	    	img.push()
   	    	img.push('latest')
   	    }

--- a/vars/paktorECRDockerImage.groovy
+++ b/vars/paktorECRDockerImage.groovy
@@ -1,0 +1,25 @@
+#!/usr/bin/env groovy
+
+/**
+ * Build and publish ECR docker images.
+ * Supports multi-regions but by default publishes to Singapore (ap-southeast-1)
+ */
+def call(regions = ['ap-southeast-1'], accountId = '373337940780') {
+    paktorCheckout scm
+
+    def imageName = (env.JOB_NAME =~ /docker-images\//).replaceFirst('')
+
+    ws(pwd() + "/docker-${imageName}") {
+        regions.each{ region ->
+            stage("Build and publish image for $region") {
+
+                def img = docker.build "${accountId}.dkr.ecr.${region}.amazonaws.com/${imageName}:${env.BUILD_NUMBER}"
+
+                aws_ecr_login("--no-include-email --region=$region")
+
+                img.push()
+                img.push('latest')
+            }
+        }
+    }
+}


### PR DESCRIPTION
Dedicated ECR pipeline helper with support for multiple regions
Remove unnecessary login for ECR from normal docker registry push
Refactor to avoid multiple checkouts when creating images for multiple regions